### PR TITLE
Fix build of GTK2 RPM

### DIFF
--- a/unison251.spec
+++ b/unison251.spec
@@ -137,10 +137,10 @@ cp -a %{SOURCE2} unison-manual.html
 unset MAKEFLAGS
 
 # we compile 2 versions: gtk2 ui and text ui
-make NATIVE=true UISTYLE=gtk2 THREADS=true
+make src NATIVE=true UISTYLE=gtk2 THREADS=true
 mv src/unison unison-gtk
 
-make NATIVE=true UISTYLE=text THREADS=true
+make src NATIVE=true UISTYLE=text THREADS=true
 mv src/unison unison-text
 mv src/unison-fsmonitor unison-fsmonitor
 


### PR DESCRIPTION
The make default target unsets all build flags, and hence the gtk rpm contains a text ui version of unison. By making the src target, the build flags remain intact.